### PR TITLE
chore: Node22 へ更新し Home UI を検証

### DIFF
--- a/.ai/tech_stack.md
+++ b/.ai/tech_stack.md
@@ -3,7 +3,7 @@
 プロジェクト全体で使用する技術要素を以下に固定する。以後の開発は本ドキュメントを唯一の参照源 (Single Source of Truth) として扱う。
 
 ## Backend
-- **言語 / Runtime**: TypeScript (Node.js 18.x)
+- **言語 / Runtime**: TypeScript (Node.js 22.x LTS)
 - **Webフレームワーク**: Fastify 4系
 - **ORM / DBアクセス**: Prisma 5系
 - **データベース**: SQLite3 (ローカルファイル、`/app/prisma/dev.db`)
@@ -26,6 +26,7 @@
 
 ## DevOps / インフラ
 - **コンテナ**: Docker / Docker Compose。Node公式 `node:18-bullseye` ベースを利用。
+ - **コンテナ**: Docker / Docker Compose。Node公式 `node:22-bullseye` ベースを利用。
 - **環境変数管理**: `.env` + Docker Compose でマッピング。
 - **ドキュメント**: Markdown (日本語)。`README_ARCHITECTURE.md` と `PROJECT_MASTER.md` を常に更新。
 - **CI/CD (予定)**: GitHub Actions で Lint / Test / Build を自動化。

--- a/PROJECT_MASTER.md
+++ b/PROJECT_MASTER.md
@@ -8,11 +8,12 @@
 - ESLint / Prettier / Vitest を backend・frontend 両方に導入し、ヘルスチェック統合テストで API 応答保証までカバーした。
 - GitHub Actions (ci.yml) で backend/frontend の lint・test・build を自動実行するパイプラインを追加。
 - フロントエンドの Home / HealthCheck / Button / API ユーティリティに解説ブロックを追加し、Button のビジュアル一貫性を守るテストを導入した。
-- backend / frontend 双方の Dockerfile を `node:18-bullseye` ベースへ差し戻し、Subject と tech_stack に沿った root ユーザー構成を維持した。
+- backend / frontend 双方の Dockerfile を `node:22-bullseye` ベースへ更新し、テスト依存が要求する Node 20+ エンジン警告を解消した。
 - backend 側の Vitest を 1.6 系へ固定し、CI で発生していた Vite ESM 読み込みエラーを解消した。
 - CI の Node.js バージョンを 22 へ更新し、ローカル環境と統一することで SharedArrayBuffer 関連の互換性問題を解決した。
 - Subject で要求されるトーナメント登録/マッチメイクの最初の UI を `Tournament` ページとして実装し、純粋関数化したロジックとユニットテストで堅牢性を担保した。
 - Tournament ページの UI 操作 (登録・重複検証・進行管理) を React Testing Library で自動化し、試合完了メッセージの表示条件も修正してユーザー体験を改善した。
+- Home ページのヒーロー要素と主要ボタンについて React Testing Library で UI テストを追加し、`useNavigate` の遷移呼び出しを検証できるようにした。
 
 ## エピックとタスク
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-bullseye
+FROM node:22-bullseye
 
 WORKDIR /app
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-bullseye
+FROM node:22-bullseye
 
 WORKDIR /app
 

--- a/frontend/src/pages/Home.test.tsx
+++ b/frontend/src/pages/Home.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * なぜテストが必要か:
+ * - Home ページのヒーローテキストや説明文がレンダリングされることを保証し、主要導線が崩れていないかを検知する。
+ * - ヘルスチェックとトーナメントへの遷移ボタンが正しいパスで `useNavigate` を呼び出すかを確認し、UX の破綻を早期に察知する。
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import HomePage from './Home'
+
+const mockNavigate = vi.fn()
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate
+  }
+})
+
+describe('HomePage', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear()
+  })
+
+  it('renders hero title, description, and navigation buttons', () => {
+    render(<HomePage />)
+
+    expect(screen.getByRole('heading', { name: 'ft_transcendence' })).toBeInTheDocument()
+    expect(
+      screen.getByText('Pong をベースにした SPA を構築する最終課題です。まずはバックエンドのヘルスチェックから動作確認しましょう。')
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'ヘルスチェックへ' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'トーナメント管理を開く' })).toBeInTheDocument()
+  })
+
+  it('navigates to health and tournament paths when buttons are clicked', async () => {
+    const user = userEvent.setup()
+    render(<HomePage />)
+
+    await user.click(screen.getByRole('button', { name: 'ヘルスチェックへ' }))
+    await user.click(screen.getByRole('button', { name: 'トーナメント管理を開く' }))
+
+    expect(mockNavigate).toHaveBeenNthCalledWith(1, '/health')
+    expect(mockNavigate).toHaveBeenNthCalledWith(2, '/tournament')
+  })
+})
+
+/*
+解説:
+
+1) mockNavigate / vi.mock
+  - React Router の `useNavigate` をテスト内で監視できるよう差し替え、リンク遷移の副作用を直接検証する。
+
+2) renders hero title ... テスト
+  - 主要コピーとボタンが DOM に存在するかを確認し、Home ページが想定どおり描画されるかを担保する。
+
+3) navigates ... テスト
+  - ユーザー操作で `useNavigate` が正しい順序と引数で呼ばれることを確認し、導線の破綻を防ぐ。
+*/


### PR DESCRIPTION
## 概要
- Homeページのヒーロー/導線をReact Testing Libraryでテストし、useNavigateの遷移を確認
- Node.js 22系イメージへ Dockerfile と tech_stack を更新し EBADENGINE 警告を解消
- PROJECT_MASTER.md にランタイム移行の進捗を追記

## テスト
- npm run test -- src/pages/Tournament.test.tsx
- npm run test -- src/pages/Home.test.tsx
- npm run lint
- npm run build
- docker compose up --build