### PR TITLE
feat: 認証API拡張

### DIFF
--- a/PROJECT_MASTER.md
+++ b/PROJECT_MASTER.md
@@ -14,7 +14,9 @@
 - `backend/prisma/schema.prisma` を草案に沿って大幅拡張（SQLite 制約に合わせ enum / JSON は String 保存へ変更）し、Prisma Client を再生成。
 - `docs/api/api_design.md` に REST + WS エンドポイント、リクエスト/レスポンス例、通知フローを整理。
 - `docs/game/pong_logic.md` でサーバ権威の Pong ループ・WebSocket イベント・AI (1 Hz 視界制約) のロジックを設計。
-- `/api/users` 検索エンドポイントを Fastify + Prisma で実装し、ページング・フィルタ・除外 ID をサポートする統合テストを追加。
+- `/api/users` 検索エンドポイントを Fastify + Prisma で実装し、ページング・フィルタ・除外 ID をサポートする統合テストを追加。mutualFriends は `Friendship` から算出し、暫定的に `X-User-Id` ヘッダーを viewer ID として扱う仕様を確立。
+- `/auth/register` を実装し、Zod バリデーション・Argon2id ハッシュ化・UUID ベース仮トークンを返す Fastify ルートと統合テストを追加。API設計書に検証ルールを反映。
+- `/auth/login` を実装し、Argon2id 検証・`Session` テーブルへのリフレッシュトークン保存・ユーザーステータス更新・統合テストを追加。MFA フローは後続タスクとして `MFA_REQUIRED` エラーを返す。
 - `/api/tournaments` (POST/GET) を追加し、トーナメント作成・一覧 API と Prisma モデル/マイグレーション、統合テストを整備。
 - `/api/tournaments/:id` で参加者・試合詳細を返すエンドポイントと統合テストを追加し、UI 設計書のコンポーネント要件と整合させた。
 - HealthCheck ページに Vitest + React Testing Library でローディング/成功/失敗/導線を検証する UI テストを追加した。
@@ -49,7 +51,7 @@
 | 状態 | タスク | メモ |
 | :---: | --- | --- |
 | ✅ | `/api/health` 実装 & テスト | 疎通確認用 |
-| 🔄 | **認証・ユーザー管理機能** | 登録/ログイン/OAuth/2FA。API設計待ち。 |
-| 🔄 | **ユーザー検索 API** | `/api/users` 実装済み。残課題: 認証・mutualFriends算出。 |
+| 🔄 | **認証・ユーザー管理機能** | `/auth/register` `/auth/login` を実装。残課題: セッション失効/更新・2FA・OAuth。 |
+| 🔄 | **ユーザー検索 API** | `/api/users` 実装済み。mutualFriends 算出完了。残課題: 認証実装とトークン連携。 |
 | 🔄 | **トーナメント API** | `/api/tournaments` (POST/GET) 実装済み。残課題: 認証・参加者編集・マッチ生成ロジック。 |
 |

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,6 +12,7 @@
         "@fastify/swagger": "^8.11.1",
         "@fastify/swagger-ui": "^1.10.0",
         "@prisma/client": "^5.8.1",
+        "argon2": "^0.44.0",
         "fastify": "^4.24.3",
         "fastify-plugin": "^4.5.0",
         "zod": "^3.22.4"
@@ -42,6 +43,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -867,6 +874,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@phc/format": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
+      "integrity": "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@pinojs/redact": {
@@ -1805,6 +1821,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/argon2": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.44.0.tgz",
+      "integrity": "sha512-zHPGN3S55sihSQo0dBbK0A5qpi2R31z7HZDZnry3ifOyj8bZZnpZND2gpmhnRGO1V/d555RwBqIK5W4Mrmv3ig==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@phc/format": "^1.0.0",
+        "cross-env": "^10.0.0",
+        "node-addon-api": "^8.5.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2045,11 +2077,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3008,7 +3056,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/js-tokens": {
@@ -3307,6 +3354,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -3478,7 +3545,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4005,7 +4071,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -4018,7 +4083,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4662,7 +4726,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
     "@fastify/swagger": "^8.11.1",
     "@fastify/swagger-ui": "^1.10.0",
     "@prisma/client": "^5.8.1",
+    "argon2": "^0.44.0",
     "fastify": "^4.24.3",
     "fastify-plugin": "^4.5.0",
     "zod": "^3.22.4"

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -6,6 +6,7 @@ import cors from '@fastify/cors'
 import dbPlugin from './plugins/db'
 import usersRoutes from './routes/users'
 import tournamentsRoutes from './routes/tournaments'
+import authRoutes from './routes/auth'
 
 if (!process.env.DATABASE_URL) {
   const sqlitePath = path.resolve(process.cwd(), 'prisma', 'dev.db')
@@ -23,6 +24,7 @@ export const buildServer = async () => {
   })
   await server.register(swaggerUi, { routePrefix: '/docs' })
   await server.register(dbPlugin)
+  await server.register(authRoutes)
   await server.register(usersRoutes)
   await server.register(tournamentsRoutes)
 

--- a/backend/src/routes/auth.test.ts
+++ b/backend/src/routes/auth.test.ts
@@ -1,0 +1,169 @@
+/**
+ * なぜテストが必要か:
+ * - `/auth/register` と `/auth/login` の入力検証・レスポンス構造・セキュリティ要件 (Argon2 ハッシュ/セッション生成) を保証する。
+ * - 認証フローが `Session` テーブルと同期し、重複登録や不正ログインに適切な HTTP ステータスを返すか継続的に検証する。
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import type { FastifyInstance } from 'fastify'
+import type { PrismaClient } from '@prisma/client'
+import argon2 from 'argon2'
+import { buildServer } from '../app'
+
+const basePayload = {
+  email: 'player@example.com',
+  username: 'player1',
+  password: 'Secure123',
+  displayName: 'Player One'
+}
+
+let server: FastifyInstance
+let prisma: PrismaClient
+
+beforeAll(async () => {
+  server = await buildServer()
+  prisma = server.prisma
+})
+
+afterAll(async () => {
+  await server.close()
+})
+
+beforeEach(async () => {
+  await prisma.session.deleteMany()
+  await prisma.user.deleteMany()
+})
+
+describe('POST /auth/register', () => {
+
+  it('creates a user with hashed password and returns tokens', async () => {
+    const response = await server.inject({
+      method: 'POST',
+      url: '/auth/register',
+      payload: basePayload
+    })
+
+    expect(response.statusCode).toBe(201)
+    const body = response.json<{ user: { id: number; login: string; displayName: string; email: string }; tokens: { access: string; refresh: string } }>()
+
+    expect(body.user).toMatchObject({
+      login: basePayload.username,
+      displayName: basePayload.displayName,
+      email: basePayload.email.toLowerCase()
+    })
+    expect(body.tokens.access).toMatch(/\w+/)
+    expect(body.tokens.refresh).toMatch(/\w+/)
+
+    const stored = await prisma.user.findUniqueOrThrow({ where: { id: body.user.id } })
+    expect(stored.passwordHash).toBeTruthy()
+    expect(stored.passwordHash).not.toBe(basePayload.password)
+    const isValid = await argon2.verify(stored.passwordHash!, basePayload.password)
+    expect(isValid).toBe(true)
+    const session = await prisma.session.findFirstOrThrow({ where: { userId: stored.id } })
+    expect(session.token).toBe(body.tokens.refresh)
+  })
+
+  it('rejects duplicate emails or usernames', async () => {
+    await server.inject({ method: 'POST', url: '/auth/register', payload: basePayload })
+
+    const response = await server.inject({
+      method: 'POST',
+      url: '/auth/register',
+      payload: {
+        ...basePayload,
+        password: 'Another123'
+      }
+    })
+
+    expect(response.statusCode).toBe(409)
+    const body = response.json<{ error: { code: string } }>()
+    expect(body.error.code).toBe('USER_ALREADY_EXISTS')
+  })
+
+  it('validates payload and returns 400 for weak password', async () => {
+    const response = await server.inject({
+      method: 'POST',
+      url: '/auth/register',
+      payload: {
+        email: 'bad',
+        username: 'p',
+        password: '123',
+        displayName: ''
+      }
+    })
+
+    expect(response.statusCode).toBe(400)
+    const body = response.json<{ error: { code: string } }>()
+    expect(body.error.code).toBe('INVALID_BODY')
+  })
+})
+
+describe('POST /auth/login', () => {
+  it('logs in with valid credentials and issues a new session', async () => {
+    const registerResponse = await server.inject({ method: 'POST', url: '/auth/register', payload: basePayload })
+    const registered = registerResponse.json<{ user: { id: number } }>()
+
+    const response = await server.inject({
+      method: 'POST',
+      url: '/auth/login',
+      payload: {
+        email: basePayload.email,
+        password: basePayload.password
+      }
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json<{
+      user: { id: number; displayName: string; status: string }
+      tokens: { access: string; refresh: string }
+      mfaRequired: boolean
+    }>()
+
+    expect(body.user).toMatchObject({ id: registered.user.id, displayName: basePayload.displayName, status: 'ONLINE' })
+    expect(body.mfaRequired).toBe(false)
+    expect(body.tokens.access).toMatch(/\w+/)
+    expect(body.tokens.refresh).toMatch(/\w+/)
+
+    const sessions = await prisma.session.findMany({ where: { userId: registered.user.id }, orderBy: { id: 'desc' } })
+    expect(sessions[0]?.token).toBe(body.tokens.refresh)
+
+    const user = await prisma.user.findUniqueOrThrow({ where: { id: registered.user.id } })
+    expect(user.status).toBe('ONLINE')
+    expect(user.lastLoginAt).not.toBeNull()
+  })
+
+  it('rejects invalid credential pairs', async () => {
+    await server.inject({ method: 'POST', url: '/auth/register', payload: basePayload })
+
+    const response = await server.inject({
+      method: 'POST',
+      url: '/auth/login',
+      payload: {
+        email: basePayload.email,
+        password: 'WrongPassword1'
+      }
+    })
+
+    expect(response.statusCode).toBe(401)
+    const body = response.json<{ error: { code: string } }>()
+    expect(body.error.code).toBe('INVALID_CREDENTIALS')
+  })
+
+  it('validates payload shape', async () => {
+    const response = await server.inject({
+      method: 'POST',
+      url: '/auth/login',
+      payload: { email: 'not-an-email', password: '123' }
+    })
+
+    expect(response.statusCode).toBe(400)
+    const body = response.json<{ error: { code: string } }>()
+    expect(body.error.code).toBe('INVALID_BODY')
+  })
+})
+
+/*
+解説:
+1) 登録 API の正常系で Argon2 ハッシュと `Session` トークンの整合を確認し、重複登録・入力エラーの応答コードも検証する。
+2) ログイン API の正常系でユーザー状態更新・新規セッショントークン発行・レスポンス構造を保証する。
+3) 不正な資格情報や入力フォーマットに対して 401/400 を返すことを確認し、セキュリティ上のガードを自動テスト化する。
+*/

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,0 +1,218 @@
+import fp from 'fastify-plugin'
+import type { FastifyPluginAsync } from 'fastify'
+import { randomUUID } from 'node:crypto'
+import argon2 from 'argon2'
+import { z } from 'zod'
+
+const SESSION_TTL_MS = 1000 * 60 * 60 * 24 * 7 // 7 days
+
+const registerSchema = z.object({
+  email: z
+    .string()
+    .trim()
+    .toLowerCase()
+    .email()
+    .max(254),
+  username: z
+    .string()
+    .trim()
+    .min(3)
+    .max(32)
+    .regex(/^[a-zA-Z0-9_-]+$/, { message: 'Only letters, numbers, _ and - are allowed' }),
+  password: z
+    .string()
+    .min(8)
+    .max(128)
+    .refine((value) => /[A-Za-z]/.test(value) && /\d/.test(value), {
+      message: 'Password must include letters and numbers'
+    }),
+  displayName: z
+    .string()
+    .trim()
+    .min(3)
+    .max(32)
+})
+
+const loginSchema = z.object({
+  email: z
+    .string()
+    .trim()
+    .toLowerCase()
+    .email()
+    .max(254),
+  password: z.string().min(8).max(128)
+})
+
+const authRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.post('/auth/register', async (request, reply) => {
+    const parsed = registerSchema.safeParse(request.body)
+
+    if (!parsed.success) {
+      reply.code(400)
+      return {
+        error: {
+          code: 'INVALID_BODY',
+          message: 'Invalid registration payload',
+          details: parsed.error.flatten().fieldErrors
+        }
+      }
+    }
+
+    const { email, username, password, displayName } = parsed.data
+
+    const existing = await fastify.prisma.user.findFirst({
+      where: {
+        OR: [{ email }, { login: username }, { displayName }]
+      },
+      select: { id: true }
+    })
+
+    if (existing) {
+      reply.code(409)
+      return {
+        error: {
+          code: 'USER_ALREADY_EXISTS',
+          message: 'User with same email/login/displayName already exists'
+        }
+      }
+    }
+
+    const passwordHash = await argon2.hash(password, { type: argon2.argon2id })
+
+    const user = await fastify.prisma.user.create({
+      data: {
+        email,
+        login: username,
+        displayName,
+        passwordHash,
+        status: 'OFFLINE',
+        profileVisibility: 'PUBLIC',
+        twoFAEnabled: false
+      },
+      select: {
+        id: true,
+        login: true,
+        displayName: true,
+        email: true,
+        status: true,
+        createdAt: true
+      }
+    })
+
+    const refreshToken = randomUUID()
+    await fastify.prisma.session.create({
+      data: {
+        userId: user.id,
+        token: refreshToken,
+        expiresAt: new Date(Date.now() + SESSION_TTL_MS)
+      }
+    })
+
+    reply.code(201)
+    return {
+      user,
+      tokens: {
+        access: randomUUID(),
+        refresh: refreshToken
+      }
+    }
+  })
+
+  fastify.post('/auth/login', async (request, reply) => {
+    const parsed = loginSchema.safeParse(request.body)
+
+    if (!parsed.success) {
+      reply.code(400)
+      return {
+        error: {
+          code: 'INVALID_BODY',
+          message: 'Invalid login payload',
+          details: parsed.error.flatten().fieldErrors
+        }
+      }
+    }
+
+    const { email, password } = parsed.data
+    const userRecord = await fastify.prisma.user.findUnique({
+      where: { email },
+      select: {
+        id: true,
+        displayName: true,
+        status: true,
+        passwordHash: true,
+        twoFAEnabled: true
+      }
+    })
+
+    if (!userRecord || !userRecord.passwordHash) {
+      reply.code(401)
+      return {
+        error: {
+          code: 'INVALID_CREDENTIALS',
+          message: 'Email or password is incorrect'
+        }
+      }
+    }
+
+    const passwordValid = await argon2.verify(userRecord.passwordHash, password)
+    if (!passwordValid) {
+      reply.code(401)
+      return {
+        error: {
+          code: 'INVALID_CREDENTIALS',
+          message: 'Email or password is incorrect'
+        }
+      }
+    }
+
+    if (userRecord.twoFAEnabled) {
+      reply.code(423)
+      return {
+        error: {
+          code: 'MFA_REQUIRED',
+          message: 'Multi-factor authentication required before issuing tokens'
+        }
+      }
+    }
+
+    const updatedUser = await fastify.prisma.user.update({
+      where: { id: userRecord.id },
+      data: {
+        status: 'ONLINE',
+        lastLoginAt: new Date()
+      },
+      select: {
+        id: true,
+        displayName: true,
+        status: true
+      }
+    })
+
+    const refreshToken = randomUUID()
+    await fastify.prisma.session.create({
+      data: {
+        userId: updatedUser.id,
+        token: refreshToken,
+        expiresAt: new Date(Date.now() + SESSION_TTL_MS)
+      }
+    })
+
+    return {
+      user: updatedUser,
+      tokens: {
+        access: randomUUID(),
+        refresh: refreshToken
+      },
+      mfaRequired: false
+    }
+  })
+}
+
+export default fp(authRoutes)
+
+/*
+解説:
+1) Zod スキーマで登録/ログイン双方の入力制約を定義し、バリデーション失敗時に 400 を即時返却する。
+2) 登録時は Argon2id でハッシュ化した上でユーザーを作成し、`Session` にリフレッシュトークンと有効期限を保存してレスポンスと同期させる。
+3) ログイン時は資格情報を検証し、2FA フラグをチェックした後に `ONLINE` へ状態更新・セッション生成・暫定アクセス/リフレッシュトークン返却を行う。
+*/

--- a/backend/src/routes/users.test.ts
+++ b/backend/src/routes/users.test.ts
@@ -17,6 +17,18 @@ const createUser = (prisma: PrismaClient, data: {
     }
   })
 
+const connectFriends = async (prisma: PrismaClient, userAId: number, userBId: number) => {
+  const [requesterId, addresseeId] = userAId < userBId ? [userAId, userBId] : [userBId, userAId]
+
+  await prisma.friendship.create({
+    data: {
+      requesterId,
+      addresseeId,
+      status: 'ACCEPTED'
+    }
+  })
+}
+
 describe('GET /api/users', () => {
   let server: FastifyInstance
   let prisma: PrismaClient
@@ -31,13 +43,14 @@ describe('GET /api/users', () => {
   })
 
   beforeEach(async () => {
+    await prisma.friendship.deleteMany()
     await prisma.user.deleteMany()
   })
 
   it('returns paginated users ordered by displayName', async () => {
-  await createUser(prisma, { login: 'carol', email: 'carol@example.com', displayName: 'Carol', status: 'OFFLINE' })
-  await createUser(prisma, { login: 'alice', email: 'alice@example.com', displayName: 'Alice', status: 'ONLINE' })
-  await createUser(prisma, { login: 'bob', email: 'bob@example.com', displayName: 'Bob', status: 'IN_MATCH' })
+    await createUser(prisma, { login: 'carol', email: 'carol@example.com', displayName: 'Carol', status: 'OFFLINE' })
+    await createUser(prisma, { login: 'alice', email: 'alice@example.com', displayName: 'Alice', status: 'ONLINE' })
+    await createUser(prisma, { login: 'bob', email: 'bob@example.com', displayName: 'Bob', status: 'IN_MATCH' })
 
     const response = await server.inject({ method: 'GET', url: '/api/users', query: { page: '1', limit: '2' } })
 
@@ -49,8 +62,8 @@ describe('GET /api/users', () => {
   })
 
   it('filters by query and status', async () => {
-  await createUser(prisma, { login: 'carol', email: 'carol@example.com', displayName: 'Carol', status: 'AWAY' })
-  await createUser(prisma, { login: 'dave', email: 'dave@example.com', displayName: 'Dave', status: 'ONLINE' })
+    await createUser(prisma, { login: 'carol', email: 'carol@example.com', displayName: 'Carol', status: 'AWAY' })
+    await createUser(prisma, { login: 'dave', email: 'dave@example.com', displayName: 'Dave', status: 'ONLINE' })
 
     const response = await server.inject({ method: 'GET', url: '/api/users', query: { q: 'car', status: 'AWAY' } })
 
@@ -62,9 +75,9 @@ describe('GET /api/users', () => {
   })
 
   it('excludes ids and clamps limit to 50', async () => {
-  const alice = await createUser(prisma, { login: 'alice', email: 'alice@example.com', displayName: 'Alice', status: 'ONLINE' })
-  await createUser(prisma, { login: 'bob', email: 'bob@example.com', displayName: 'Bob', status: 'ONLINE' })
-  await createUser(prisma, { login: 'carol', email: 'carol@example.com', displayName: 'Carol', status: 'ONLINE' })
+    const alice = await createUser(prisma, { login: 'alice', email: 'alice@example.com', displayName: 'Alice', status: 'ONLINE' })
+    await createUser(prisma, { login: 'bob', email: 'bob@example.com', displayName: 'Bob', status: 'ONLINE' })
+    await createUser(prisma, { login: 'carol', email: 'carol@example.com', displayName: 'Carol', status: 'ONLINE' })
 
     const response = await server.inject({
       method: 'GET',
@@ -82,6 +95,31 @@ describe('GET /api/users', () => {
     expect(body.data.find((item) => item.id === alice.id)).toBeUndefined()
   })
 
+  it('computes mutual friend counts using viewer header', async () => {
+    const viewer = await createUser(prisma, { login: 'viewer', email: 'viewer@example.com', displayName: 'Viewer', status: 'ONLINE' })
+    const ally = await createUser(prisma, { login: 'ally', email: 'ally@example.com', displayName: 'Ally', status: 'ONLINE' })
+    const buddy = await createUser(prisma, { login: 'buddy', email: 'buddy@example.com', displayName: 'Buddy', status: 'ONLINE' })
+    const stranger = await createUser(prisma, { login: 'stranger', email: 'stranger@example.com', displayName: 'Stranger', status: 'ONLINE' })
+    const target = await createUser(prisma, { login: 'target', email: 'target@example.com', displayName: 'Target', status: 'ONLINE' })
+
+    await connectFriends(prisma, viewer.id, ally.id)
+    await connectFriends(prisma, viewer.id, buddy.id)
+    await connectFriends(prisma, target.id, ally.id)
+    await connectFriends(prisma, target.id, buddy.id)
+    await connectFriends(prisma, target.id, stranger.id)
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/api/users',
+      headers: { 'x-user-id': viewer.id.toString() },
+      query: { q: 'Target' }
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json<{ data: Array<{ id: number; mutualFriends: number }> }>()
+    expect(body.data[0]).toMatchObject({ id: target.id, mutualFriends: 2 })
+  })
+
   it('returns 400 for invalid query params', async () => {
     const response = await server.inject({ method: 'GET', url: '/api/users', query: { limit: '0' } })
 
@@ -90,3 +128,10 @@ describe('GET /api/users', () => {
     expect(body.error.code).toBe('INVALID_QUERY')
   })
 })
+
+/*
+解説:
+1) connectFriends ヘルパーを導入し、双方向フレンドシップの生成と `status = ACCEPTED` 固定を簡潔にした。
+2) beforeEach で `friendship` テーブルも掃除することで、テスト間の外部キー汚染を防ぐ。
+3) 新規テストでは `X-User-Id` を用いた viewer コンテキストで相互友人数が期待通り 2 となることを検証し、API 仕様の暫定要件を自動化した。
+*/


### PR DESCRIPTION
## 概要
-  にセッション生成を追加し、Argon2id ハッシュと同期させました。
-  を実装し、パスワード検証・セッション発行・ ステータス更新・MFA Required エラー分岐を追加しました。
-  の mutualFriends 算出仕様をドキュメント＆実装に反映し、テストを拡充しました。
-  と API 設計書を更新しました。

## テスト
- 
- 
- 
