### PR TITLE
fix(users): map frontend query -> q and avoid sending empty q param

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -346,7 +346,17 @@ export type UserSearchParams = {
 }
 
 export const fetchUsers = async (params: UserSearchParams = {}) => {
-  const response = await apiClient.get('/users', { params })
+  // Backend expects `q` as the search query param. Frontend types use `query`.
+  const sendParams: Record<string, any> = { ...params }
+  // Only include `q` when a non-empty query is provided. Backend validation
+  // rejects empty strings (schema expects min length 1), so omit empty.
+  if (typeof params.query === 'string' && params.query.trim().length > 0) {
+    sendParams.q = params.query.trim()
+  }
+  // Remove frontend-only `query` key before sending
+  delete sendParams.query
+
+  const response = await apiClient.get('/users', { params: sendParams })
   return response.data as UserSearchResponse
 }
 

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -13,7 +13,7 @@ const UsersPage = () => {
     limit: 20,
     sortBy: 'displayName',
     order: 'asc',
-    query: ''
+    query: undefined
   })
   const { user: currentUser } = useAuthStore()
   const [myFriends, setMyFriends] = useState<number[]>([])
@@ -81,8 +81,8 @@ const UsersPage = () => {
             type="text"
             placeholder="名前で検索..."
             className="rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-            value={params.query}
-            onChange={(e) => setParams((prev) => ({ ...prev, query: e.target.value, page: 1 }))}
+            value={params.query ?? ''}
+            onChange={(e) => setParams((prev) => ({ ...prev, query: e.target.value || undefined, page: 1 }))}
           />
         </form>
       </div>


### PR DESCRIPTION
Maps frontend  param to backend  and prevents sending empty queries; see commit for details.