### PR TITLE
Remove unique constraint on displayName

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -12,7 +12,7 @@ model User {
   login                 String              @unique
   intraId               String?             @unique
   email                 String              @unique
-  displayName           String              @unique
+  displayName           String
   passwordHash          String?
   avatarUrl             String?
   bio                   String?


### PR DESCRIPTION
Remove DB-level unique constraint on User.displayName and stop enforcing uniqueness in auth routes. Normalize/sanitize provider display names instead of generating unique variants.