### PR TITLE
Remove unique constraint on displayName (follow-up)

### DIFF
--- a/backend/prisma/migrations/20251130071539_drop_displayname_unique/migration.sql
+++ b/backend/prisma/migrations/20251130071539_drop_displayname_unique/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "User_displayName_key";


### PR DESCRIPTION
This PR removes the DB-level unique constraint on User.displayName and stops enforcing uniqueness in auth logic. It includes the generated Prisma migration. Please review and run migrations in your environment before deploying.