### PR TITLE
fix(frontend): プロフィール画面で長いBioが表示崩れを起こす問題を修正

### DIFF
--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -364,7 +364,7 @@ const ProfilePage = () => {
       {/* Hero Section */}
       <div className="mb-8 flex flex-col items-center gap-6 rounded-xl border border-slate-200 bg-white p-8 shadow-sm sm:flex-row sm:items-start dark:border-slate-700 dark:bg-slate-800">
         <div 
-          className={`relative cursor-pointer group`} 
+          className={`relative cursor-pointer group shrink-0`} 
           onClick={() => {
             if (isOwnProfile) {
               setEditModalField('avatar')
@@ -392,7 +392,7 @@ const ProfilePage = () => {
             </div>
           )}
         </div>
-        <div className="flex-1 text-center sm:text-left">
+        <div className="flex-1 min-w-0 text-center sm:text-left">
           <div className="flex flex-col items-center sm:items-start">
             {editingField === 'displayName' ? (
               <div className="relative inline-grid items-center justify-items-center sm:justify-items-start">
@@ -443,7 +443,7 @@ const ProfilePage = () => {
           ) : (
             (profile.bio || isOwnProfile) && (
               <p 
-                className={`mt-2 text-slate-600 dark:text-slate-400 ${isOwnProfile ? 'cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-700/50 rounded px-2 -mx-2 transition-colors' : ''}`}
+                className={`mt-2 text-slate-600 dark:text-slate-400 break-words whitespace-pre-wrap ${isOwnProfile ? 'cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-700/50 rounded px-2 -mx-2 transition-colors' : ''}`}
                 onClick={() => isOwnProfile && startEditing('bio', profile.bio)}
                 title={isOwnProfile ? "Click to edit bio" : undefined}
               >


### PR DESCRIPTION
## 概要
プロフィール画面において、Bio（自己紹介）に長いテキスト（81文字以上など）が入力された際、レイアウトが崩れてアバター画像が消失したり、テキストが枠外にはみ出したりする問題を修正しました。

## 変更点
- `frontend/src/pages/Profile.tsx`
  - アバター画像のコンテナに `shrink-0` を追加し、画面幅が狭くなってもアバターが潰れないようにしました。
  - テキストコンテナ（`flex-1`）に `min-w-0` を追加し、Flexbox内でのテキスト折り返しが正しく機能するようにしました。
  - Bioの表示部分に `break-words` と `whitespace-pre-wrap` を追加し、長い単語の折り返しと改行の維持を適用しました。

## 確認方法
1. プロフィール編集でBioに長い文字列（スペースなしの連続した文字や、長い文章）を入力して保存する。
2. プロフィール画面でアバターが正しく表示され、Bioのテキストが枠内で折り返されていることを確認する。

## 関連Issue
- #47